### PR TITLE
Use Redis for order storage and chef-specific production lists

### DIFF
--- a/handlers/webhookHandler.js
+++ b/handlers/webhookHandler.js
@@ -53,7 +53,7 @@ router.get('/payment-success', async (req, res) => {
         `✅ Payment received for order #${orderId}. Your order is confirmed.`
       );
     } else {
-      confirmOrder(whatsappNumber, 'Online', orderId, true);
+      confirmOrder(whatsappNumber, null, [], 'Online', orderId, true);
     }
     res.status(200).send('Payment confirmed');
   } else {
@@ -87,7 +87,7 @@ router.post('/razorpay-webhook-tfcmarket', async (req, res) => {
           `✅ Payment received for order #${orderId}. Your order is confirmed.`
         );
       } else {
-        confirmOrder(whatsappNumber, 'Online', orderId, true);
+        confirmOrder(whatsappNumber, null, [], 'Online', orderId, true);
       }
     }
   }

--- a/services/orderService.js
+++ b/services/orderService.js
@@ -1,21 +1,23 @@
 const { appendToCsv } = require('../utils/csvUtils');
 const {
-  ORDERS_CSV,
   SUPERVISORS,
   SCHEDULED_MESSAGES_CSV,
 } = require('../config/settings');
 const { formatISTDateTime, getCurrentIST } = require('../utils/timeUtils');
 const { sendTextMessage } = require('./whatsappService');
 const logger = require('../utils/logger');
+const redisState = require('../stateHandlers/redisState');
 
-function confirmOrder(whatsappNumber, paymentType, orderId, paid = false) {
+function confirmOrder(whatsappNumber, branch, items, paymentType, orderId, paid = false) {
   const timestamp = formatISTDateTime();
-  appendToCsv(ORDERS_CSV, {
+  redisState.addConfirmedOrder({
     timestamp,
     whatsapp_number: whatsappNumber,
+    branch,
+    items,
     order_id: orderId,
     payment_type: paymentType,
-    payment_status: paid ? 'Paid' : 'Pending'
+    payment_status: paid ? 'Paid' : 'Pending',
   });
   logger.info(`Order confirmed for ${whatsappNumber}`);
 }
@@ -62,7 +64,7 @@ async function finalizeOrder(
   orderId,
   paid = false
 ) {
-  confirmOrder(whatsappNumber, paymentType, orderId, paid);
+  confirmOrder(whatsappNumber, branch, items, paymentType, orderId, paid);
   await notifySupervisors(orderId, branch, items);
 }
 


### PR DESCRIPTION
## Summary
- Persist confirmed orders in Redis instead of CSV
- Aggregate Redis orders to build chef-specific production and delivery lists
- Archive branch orders after daily delivery notifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8128e6884832797d97fdf0a942557