### PR TITLE
Restrict delivery status updates to branches with active orders

### DIFF
--- a/handlers/messageHandler.js
+++ b/handlers/messageHandler.js
@@ -52,12 +52,20 @@ async function handleIncomingMessage(data) {
               (b) => b.toLowerCase() === branchText.toLowerCase()
             );
             if (branch) {
-              if (status === 'delivered') {
-                await redisState.markBranchDelivered(branch);
+              const hasOrders = await redisState.branchHasOrders(branch);
+              if (!hasOrders) {
+                await sendTextMessage(
+                  sender,
+                  `No active orders for ${branch}.`
+                );
               } else {
-                await redisState.setBranchDeliveryStatus(branch, status);
+                if (status === 'delivered') {
+                  await redisState.markBranchDelivered(branch);
+                } else {
+                  await redisState.setBranchDeliveryStatus(branch, status);
+                }
+                await sendDeliveryConfirmation(sender, branch, status);
               }
-              await sendDeliveryConfirmation(sender, branch, status);
             } else {
               await sendTextMessage(
                 sender,

--- a/services/whatsappService.js
+++ b/services/whatsappService.js
@@ -356,12 +356,14 @@ async function sendBranchDeliveryInstructions(to) {
 
 async function sendDeliveryStatus(to) {
   const statuses = await redisState.getDeliveryStatuses();
+  const branches = await redisState.getBranchesWithOrders();
   let message = '📦 *CURRENT DELIVERY STATUS*\n\n';
-  if (Object.keys(statuses).length === 0) {
+  if (!branches.length) {
     message += 'No branches have pending deliveries.';
   } else {
-    Object.keys(statuses).forEach((branch) => {
-      message += `• ${toTitleCase(branch)}: ${toTitleCase(statuses[branch])}\n`;
+    branches.forEach((branch) => {
+      const status = statuses[branch] || 'pending';
+      message += `• ${toTitleCase(branch)}: ${toTitleCase(status)}\n`;
     });
   }
   return sendTextMessage(to, message);

--- a/stateHandlers/redisState.js
+++ b/stateHandlers/redisState.js
@@ -115,6 +115,33 @@ async function addConfirmedOrder(order) {
   }
 }
 
+async function branchHasOrders(branch) {
+  try {
+    const count = await redis.llen(`orders:${branch.toLowerCase()}`);
+    return count > 0;
+  } catch (err) {
+    logger.error(`Failed to check orders for ${branch}: ${err.message}`);
+    return false;
+  }
+}
+
+async function getBranchesWithOrders() {
+  try {
+    const keys = await redis.keys('orders:*');
+    const branches = [];
+    for (const key of keys) {
+      const count = await redis.llen(key);
+      if (count > 0) {
+        branches.push(key.split(':')[1]);
+      }
+    }
+    return branches;
+  } catch (err) {
+    logger.error(`Failed to fetch branches with orders: ${err.message}`);
+    return [];
+  }
+}
+
 async function getAllOrders() {
   try {
     const keys = await redis.keys('orders:*');
@@ -197,6 +224,8 @@ module.exports = {
   getPendingOrder,
   deletePendingOrder,
   addConfirmedOrder,
+  branchHasOrders,
+  getBranchesWithOrders,
   getAllOrders,
   archiveOrders,
   setBranchDeliveryStatus,


### PR DESCRIPTION
## Summary
- add Redis helpers to check for active branch orders
- prevent delivery staff from updating status when a branch has no orders
- show delivery status only for branches that currently have orders

## Testing
- `node --check handlers/messageHandler.js`
- `node --check services/whatsappService.js`
- `node --check stateHandlers/redisState.js`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b81fcff8d08327a957bed71a18109f