### PR TITLE
feat: show detailed delivery status

### DIFF
--- a/services/whatsappService.js
+++ b/services/whatsappService.js
@@ -357,16 +357,25 @@ async function sendBranchDeliveryInstructions(to) {
 async function sendDeliveryStatus(to) {
   const statuses = await redisState.getDeliveryStatuses();
   const branches = await redisState.getBranchesWithOrders();
+  const counts = await redisState.getBranchOrderCounts();
   let message = '📦 *CURRENT DELIVERY STATUS*\n\n';
   if (!branches.length) {
     message += 'No branches have pending deliveries.';
   } else {
     branches.forEach((branch) => {
       const status = statuses[branch] || 'pending';
-      message += `• ${toTitleCase(branch)}: ${toTitleCase(status)}\n`;
+      const orders = counts[branch] || 0;
+      const ready = status === 'ready' ? 1 : 0;
+      const delivered = status === 'delivered' ? 1 : 0;
+      message += `${toTitleCase(branch)}:\n`;
+      message += `orders: ${orders}(if orders are placed multiple times before next day 7am all orders needs to be delivered next day)\n`;
+      message += `Ready: ${ready}\n`;
+      message += `delivered: ${delivered}\n`;
+      message += delivered > 0 ? 'all orders delivered for the day for this branch\n' : 'orders not yet delivered.\n';
+      message += '\n';
     });
   }
-  return sendTextMessage(to, message);
+  return sendTextMessage(to, message.trim());
 }
 
 async function sendDeliveryConfirmation(to, branch, status) {

--- a/stateHandlers/redisState.js
+++ b/stateHandlers/redisState.js
@@ -142,6 +142,22 @@ async function getBranchesWithOrders() {
   }
 }
 
+async function getBranchOrderCounts() {
+  try {
+    const keys = await redis.keys('orders:*');
+    const counts = {};
+    for (const key of keys) {
+      const branch = key.split(':')[1];
+      const count = await redis.llen(key);
+      counts[branch] = count;
+    }
+    return counts;
+  } catch (err) {
+    logger.error(`Failed to fetch branch order counts: ${err.message}`);
+    return {};
+  }
+}
+
 async function getAllOrders() {
   try {
     const keys = await redis.keys('orders:*');
@@ -226,6 +242,7 @@ module.exports = {
   addConfirmedOrder,
   branchHasOrders,
   getBranchesWithOrders,
+  getBranchOrderCounts,
   getAllOrders,
   archiveOrders,
   setBranchDeliveryStatus,


### PR DESCRIPTION
## Summary
- add Redis helper to count orders per branch
- expand delivery status message with order counts and delivery summary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8234cff00832797e946cadbd0b50d