### PR TITLE
Fix delivery status reporting after order completion

### DIFF
--- a/services/whatsappService.js
+++ b/services/whatsappService.js
@@ -368,9 +368,9 @@ async function sendDeliveryStatus(to) {
       const ready = status === 'ready' ? 1 : 0;
       const delivered = status === 'delivered' ? 1 : 0;
       message += `${toTitleCase(branch)}:\n`;
-      message += `orders: ${orders}(if orders are placed multiple times before next day 7am all orders needs to be delivered next day)\n`;
+      message += `Orders: ${orders}\n`;
       message += `Ready: ${ready}\n`;
-      message += `delivered: ${delivered}\n`;
+      message += `Delivered: ${delivered}\n`;
       message += delivered > 0 ? 'all orders delivered for the day for this branch\n' : 'orders not yet delivered.\n';
       message += '\n';
     });

--- a/stateHandlers/redisState.js
+++ b/stateHandlers/redisState.js
@@ -205,8 +205,8 @@ async function markBranchDelivered(branch) {
       ? { ...JSON.parse(existing), status: 'delivered', updated_at: Date.now() }
       : { status: 'delivered', updated_at: Date.now() };
     const archiveKey = `delivery_archive:${branch.toLowerCase()}:${Date.now()}`;
+    await redis.set(key, JSON.stringify(payload));
     await redis.set(archiveKey, JSON.stringify(payload), 'EX', 3 * 24 * 60 * 60);
-    await redis.del(key);
   } catch (err) {
     logger.error(`Failed to archive delivery status for ${branch}: ${err.message}`);
   }


### PR DESCRIPTION
## Summary
- Preserve branch delivery status after marking as delivered
- Remove extraneous note from delivery status messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b825c9b8b8832790fe185786e17052